### PR TITLE
Make sure typeof value=="number" before calling value.toFixed

### DIFF
--- a/src/masks.js
+++ b/src/masks.js
@@ -459,6 +459,12 @@
 					if(!value) {
 						return value;
 					}
+					if(typeof value != 'number') {
+						if(isNaN(parseFloat(value))) {
+							return value;
+						}
+						value = parseFloat(value);
+					}
 
 					return moneyMask.apply(value.toFixed(decimals).replace(/[^\d]+/g,''));
 				});


### PR DESCRIPTION
In some cases ng-model may initially contain a string value, in this case `"0.00".toFixed(2)` will raise "TypeError: undefined is not a function".
