### PR TITLE
Including option to specify format to parse on ui-date-mask

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -64,8 +64,18 @@ angular.module('ui.utils.masks.date', dependencies)
 				if(angular.isUndefined(value)) {
 					return;
 				}
+				
+				var parsedDate = moment(value);
 
-				var formatedValue = applyMask(moment(value).format(dateFormat));
+                if (angular.isDefined(attrs.uiDateParse)) {
+                    var parsedDateCustom = moment(value, attrs.uiDateParse);
+
+                    if(parsedDateCustom.isValid()) {
+                        parsedDate = parsedDateCustom;
+                    }
+                }
+
+				var formatedValue = applyMask(parsedDate.format(dateFormat));
 				validator(formatedValue);
 				return formatedValue;
 			}

--- a/src/date.js
+++ b/src/date.js
@@ -67,13 +67,13 @@ angular.module('ui.utils.masks.date', dependencies)
 				
 				var parsedDate = moment(value);
 
-                if (angular.isDefined(attrs.uiDateParse)) {
-                    var parsedDateCustom = moment(value, attrs.uiDateParse);
+				if (angular.isDefined(attrs.uiDateParse)) {
+					var parsedDateCustom = moment(value, attrs.uiDateParse);
 
-                    if(parsedDateCustom.isValid()) {
-                        parsedDate = parsedDateCustom;
-                    }
-                }
+					if(parsedDateCustom.isValid()) {
+						parsedDate = parsedDateCustom;
+					}
+				}
 
 				var formatedValue = applyMask(parsedDate.format(dateFormat));
 				validator(formatedValue);

--- a/src/date.js
+++ b/src/date.js
@@ -61,7 +61,7 @@ angular.module('ui.utils.masks.date', dependencies)
 
 			function formatter (value) {
 				$log.debug('[uiDateMask] Formatter called: ', value);
-				if(angular.isUndefined(value)) {
+				if(angular.isUndefined(value) || !value) {
 					return;
 				}
 				


### PR DESCRIPTION
Added option ```ui-date-parse=""``` to specify format to parse the date string on ```ui-date-mask```.