### PR TITLE
Proper binding of phone number

### DIFF
--- a/src/phone.js
+++ b/src/phone.js
@@ -32,7 +32,7 @@ angular.module('ui.utils.masks.phone', [])
 		}
 
 		var formatedValue;
-		if(value.length < 11){
+		if(value.toString().length < 11){
 			formatedValue = phoneMask8D.apply(value);
 		}else{
 			formatedValue = phoneMask9D.apply(value);


### PR DESCRIPTION
Since the mask may expect a number, JavaScript may pass a Number object. To be comparable with length property, must transform into a String object, otherwise property will be undefined.