### PR TITLE
Use the same locale in angular and moment.js

### DIFF
--- a/src/global/date/date.js
+++ b/src/global/date/date.js
@@ -65,7 +65,7 @@ angular.module('ui.utils.masks.global.date', dependencies)
 					return;
 				}
 
-				var formatedValue = applyMask(moment(value).format(dateFormat));
+				var formatedValue = applyMask(moment().locale($locale.id).format(value));
 				validator(formatedValue);
 				return formatedValue;
 			}


### PR DESCRIPTION
Please set the same locale on moment and $locale for fix "wrong date" when you try use pt-br locale in angular and your local locale is en_US, because moment use user locale.