### PR TITLE
ignore specs in jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -18,6 +18,7 @@
     "trailing": true,
     "smarttabs": false,
     "expr": true,
+    "jasmine": true,
     "globals": {
         "angular": true
     },
@@ -33,6 +34,7 @@
         "afterEach",
         "it",
         "StringMask",
+        "TestUtil",
         "BrV"
     ],
     "indent": 4,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var gulp = require('gulp'),
 var path = {
 	src: {
 		files: ['src/**/*.js'],
+		jshint: ['src/**/*.js', '!src/**/*.spec.js'],
 		e2e: ['src/**/*.spec.js']
 	},
 	lib: {
@@ -20,7 +21,7 @@ var path = {
 }
 
 gulp.task('jshint', function() {
-	gulp.src(path.src.files)
+	gulp.src(path.src.jshint)
 	.pipe(plugins.jshint('.jshintrc'))
 	.pipe(plugins.jshint.reporter(jshintReporter));
 });


### PR DESCRIPTION
Currently when running gulp joshing, there are plenty of bogus warnings. This fixes those for regular JS files and karma tests. There are still random warnings in protractor specs, but for now this just ignores those files. If we would start ignoring specific things protractor specs need, that would need to be a separate jshint task to avoid ignoring the same stuff in regular JS files.