### PR TITLE
Add US phone number formatter

### DIFF
--- a/demo/us.html
+++ b/demo/us.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Angular Mask US Demo</title>
+	<script src="../bower_components/angular/angular.min.js"></script>
+	<script src="../releases/masks.us.js"></script>
+	<script>
+		angular.module('demo', ['ui.utils.masks.us']);
+
+		function ctrl($scope) {
+			$scope.initializedPhoneNumber = '3133536767';
+		}
+	</script>
+</head>
+<body ng-app="demo">
+	<form name="form" ng-controller="ctrl">
+		<h2>ui-us-phone-number</h2>
+		<input id="us-phone-input" type="text" name="phoneNumberTest" ng-model="phoneNumber" ui-us-phone-number><br>
+		<span id="us-phone-value">{{phoneNumber}}</span> - {{form.phoneNumberTest.$valid}}<br>
+		<br>
+		<input id="init-us-phone-input" type="text" name="initializedPhoneNumberTest" ng-model="initializedPhoneNumber" ui-us-phone-number><br>
+		<span id="init-us-phone-value">{{initializedPhoneNumber}}</span> - {{form.initializedPhoneNumberTest.$valid}}<br>
+		<br>
+	</form>
+</body>
+</html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,13 +8,20 @@ var gulp = require('gulp'),
 
 var path = {
 	src: {
-		files: ['src/**/*.js'],
-		e2e: ['src/**/*.spec.js']
+		files: ['src/**/*.js', '!src/us/**/*.js'],
+		e2e: ['src/**/*.spec.js', '!src/global/us/*.spec.js']
+	},
+	us: {
+		files: ['src/helpers.js', 'src/global/**/*.js', 'src/us/**/*.js'],
+		e2e: ['src/global/**/*.spec.js', 'src/global/us/*.spec.js']
 	},
 	lib: {
 		files: [
 			'bower_components/string-mask/src/string-mask.js',
 			'bower_components/br-validations/releases/br-validations.js'
+		],
+		us: [
+			'bower_components/string-mask/src/string-mask.js'
 		]
 	}
 }
@@ -54,6 +61,18 @@ gulp.task('build', function() {
 	.pipe(gulp.dest('./releases/'))
 	.pipe(plugins.uglify())
 	.pipe(plugins.concat('masks.min.js'))
+	.pipe(gulp.dest('./releases/'));
+
+	gulp.src(
+		path.lib.us.concat(path.us.files)
+	)
+	.pipe(filterNonCodeFiles())
+	.pipe(plugins.concat('masks.us.js'))
+	.pipe(plugins.header(header, {pkg: pkg}))
+	.pipe(plugins.footer(footer))
+	.pipe(gulp.dest('./releases/'))
+	.pipe(plugins.uglify())
+	.pipe(plugins.concat('masks.us.min.js'))
 	.pipe(gulp.dest('./releases/'));
 });
 

--- a/src/us/phone/us-phone.js
+++ b/src/us/phone/us-phone.js
@@ -1,0 +1,72 @@
+'use strict';
+
+angular.module('ui.utils.masks.us.phone', [])
+.factory('usPhoneValidators', [function() {
+	return {
+		usPhoneNumber: function (ctrl, value) {
+			var valid = ctrl.$isEmpty(value) || (value.length > 9);
+			ctrl.$setValidity('us-phone-number', valid);
+			return value;
+		}
+	};
+}])
+.directive('uiUsPhoneNumber', ['usPhoneValidators', function(usPhoneValidators) {
+	var phoneMaskUS = new StringMask('(000) 000-0000'),
+		phoneMaskINTL = new StringMask('+00-00-000-000000');
+
+	function clearValue (value) {
+		if(!value) {
+			return value;
+		}
+		return value.replace(/[^0-9]/g, '');
+	}
+
+	function applyPhoneMask (value) {
+		if(!value) {
+			return value;
+		}
+
+		var formatedValue;
+		if(value.length < 11){
+			formatedValue = phoneMaskUS.apply(value);
+		}else{
+			formatedValue = phoneMaskINTL.apply(value);
+		}
+
+		return formatedValue.trim().replace(/[^0-9]$/, '');
+	}
+
+	return {
+		restrict: 'A',
+		require: '?ngModel',
+		link: function(scope, element, attrs, ctrl) {
+			if (!ctrl) {
+				return;
+			}
+
+			ctrl.$formatters.push(function(value) {
+				return applyPhoneMask(usPhoneValidators.usPhoneNumber(ctrl, value));
+			});
+
+			ctrl.$parsers.push(function(value) {
+				if (!value) {
+					return value;
+				}
+
+				var cleanValue = clearValue(value);
+				var formatedValue = applyPhoneMask(cleanValue);
+
+				if (ctrl.$viewValue !== formatedValue) {
+					ctrl.$setViewValue(formatedValue);
+					ctrl.$render();
+				}
+
+				return clearValue(formatedValue);
+			});
+
+			ctrl.$parsers.push(function(value) {
+				return usPhoneValidators.usPhoneNumber(ctrl, value);
+			});
+		}
+	};
+}]);

--- a/src/us/phone/us-phone.spec.js
+++ b/src/us/phone/us-phone.spec.js
@@ -1,0 +1,68 @@
+var StringMask = require('string-mask');
+
+describe('ui.utils.masks.us.phone', function () {
+	beforeEach(function () {
+		browser.get('/demo/us.html');
+	});
+
+	it('should load the demo page', function () {
+		expect(browser.getTitle()).toEqual('Angular Mask US Demo');
+	});
+
+	describe('ui-us-phone-number:', function () {
+		var runTests = function (input, value) {
+			var BS = protractor.Key.BACK_SPACE;
+			var tests = [
+				{key: '1', viewValue: '(1', modelValue: '1'},
+				{key: '2', viewValue: '(12', modelValue: '12'},
+				{key: '3', viewValue: '(123', modelValue: '123'},
+				{key: '4', viewValue: '(123) 4', modelValue: '1234'},
+				{key: '5', viewValue: '(123) 45', modelValue: '12345'},
+				{key: '6', viewValue: '(123) 456', modelValue: '123456'},
+				{key: '7', viewValue: '(123) 456-7', modelValue: '1234567'},
+				{key: '8', viewValue: '(123) 456-78', modelValue: '12345678'},
+				{key: '9', viewValue: '(123) 456-789', modelValue: '123456789'},
+				{key: '0', viewValue: '(123) 456-7890', modelValue: '1234567890'},
+				{key: '1', viewValue: '+12-34-567-8901', modelValue: '12345678901'},
+				{key: '2', viewValue: '+12-34-567-89012', modelValue: '123456789012'},
+				{key: '3', viewValue: '+12-34-567-890123', modelValue: '1234567890123'},
+				{key: BS, viewValue: '+12-34-567-89012', modelValue: '123456789012'},
+				{key: BS, viewValue: '+12-34-567-8901', modelValue: '12345678901'},
+				{key: BS, viewValue: '(123) 456-7890', modelValue: '1234567890'},
+				{key: BS, viewValue: '(123) 456-789', modelValue: '123456789'},
+				{key: BS, viewValue: '(123) 456-78', modelValue: '12345678'},
+				{key: BS, viewValue: '(123) 456-7', modelValue: '1234567'},
+				{key: BS, viewValue: '(123) 456', modelValue: '123456'},
+				{key: BS, viewValue: '(123) 45', modelValue: '12345'},
+				{key: BS, viewValue: '(123) 4', modelValue: '1234'},
+				{key: BS, viewValue: '(123', modelValue: '123'},
+				{key: BS, viewValue: '(12', modelValue: '12'},
+				{key: BS, viewValue: '(1', modelValue: '1'},
+				{key: BS, viewValue: '', modelValue: ''},
+			];
+
+			for (var i = 0; i < tests.length; i++) {
+				input.sendKeys(tests[i].key);
+				expect(input.getAttribute('value')).toEqual(tests[i].viewValue);
+				expect(value.getText()).toEqual(tests[i].modelValue);
+			}
+		}
+
+		it('should apply a phone number mask while the user is typing:', function () {
+			var input = element(by.id('us-phone-input')),
+				value = element(by.id('us-phone-value'));
+
+			runTests(input, value);
+		});
+
+		it('should apply a phone number mask in a model with default value:', function () {
+			var input = element(by.id('init-us-phone-input')),
+				value = element(by.id('init-us-phone-value'));
+
+			expect(input.getAttribute('value')).toEqual('(313) 353-6767');
+			input.clear();
+
+			runTests(input, value);
+		});
+	});
+});

--- a/src/us/phone/us-phone.test.js
+++ b/src/us/phone/us-phone.test.js
@@ -1,0 +1,48 @@
+describe('ui-us-phone-mask', function() {
+	beforeEach(module('ui.utils.masks.us.phone'));
+
+	it('should not throw an error if used without ng-model', function() {
+		expect(function() {
+			TestUtil.compile('<input ui-us-phone-number>');
+		}).not.toThrow();
+	});
+
+	it('should register a $formatter', function() {
+		var input = TestUtil.compile('<input ng-model="model">');
+		var model = input.controller('ngModel');
+
+		var maskedInput = TestUtil.compile('<input ng-model="maskedModel" ui-us-phone-number>');
+		var maskedModel = maskedInput.controller('ngModel');
+
+		expect(maskedModel.$formatters.length).toBe(model.$formatters.length + 1);
+	});
+
+	it('should format initial model values', function() {
+		var input = TestUtil.compile('<input ng-model="model" ui-us-phone-number>', {
+			model: '3011201034'
+		});
+
+		var model = input.controller('ngModel');
+		expect(model.$viewValue).toBe('(301) 120-1034');
+	});
+
+	it('should ignore non digits', function() {
+		var input = TestUtil.compile('<input ng-model="model" ui-us-phone-number>');
+		var model = input.controller('ngModel');
+
+		var tests = [
+			{value:'@', viewValue:'', modelValue:''},
+			{value:'2-', viewValue:'(2', modelValue:'2'},
+			{value:'23a', viewValue:'(23', modelValue:'23'},
+			{value:'23_34', viewValue:'(233) 4', modelValue:'2334'},
+			{value:'23346!', viewValue:'(233) 46', modelValue:'23346'},
+			{value:'23346!32400', viewValue:'(233) 463-2400', modelValue:'2334632400'},
+		];
+
+		tests.forEach(function(test) {
+			input.val(test.value).triggerHandler('input');
+			expect(model.$viewValue).toBe(test.viewValue);
+			expect(model.$modelValue).toBe(test.modelValue);
+		});
+	});
+});

--- a/src/us/us-masks.js
+++ b/src/us/us-masks.js
@@ -1,0 +1,6 @@
+'use strict';
+
+angular.module('ui.utils.masks.us', [
+	'ui.utils.masks.global',
+	'ui.utils.masks.us.phone'
+]);


### PR DESCRIPTION
Added US phone formatter with a separate protractor test and a karma test, and a tweaked the gulp file to create a separate build file masks.us.js that only has the global masks and the new us phone mask.

There is probably a cleaner way to do the whole BR vs US thing, but for now I tried to do it in a way that leaves the existing stuff alone. Further splitting up can be done separately.

NOTE that I use element by id in protractor tests because by model and by bind seem to create warnings even in existing tests.