### PR TITLE
setValidity camelCase

### DIFF
--- a/src/br/phone/br-phone.js
+++ b/src/br/phone/br-phone.js
@@ -5,7 +5,7 @@ angular.module('ui.utils.masks.br.phone', [])
 	return {
 		brPhoneNumber: function (ctrl, value) {
 			var valid = ctrl.$isEmpty(value) || value.length === 10 || value.length === 11;
-			ctrl.$setValidity('br-phone-number', valid);
+			ctrl.$setValidity('brPhoneNumber', valid);
 			return value;
 		}
 	};


### PR DESCRIPTION
I got problems to show error message

<small class="error" ng-show="form_agendamentopericia.telefone.$error.br-phone-number "> inválido</small>

So I changed to brPhoneNumber, and it works fine now.

ctrl.$setValidity('brPhoneNumber', valid);

<small class="error" ng-show="form_agendamentopericia.telefone.$error.brPhoneNumber "> inválido</small>

I have found this in angular documentation:

$setValidity(validationErrorKey, isValid): The validationErrorKey should be in camelCase.

https://docs.angularjs.org/api/ng/type/ngModel.NgModelController