### PR TITLE
ui-br-cep-mask should accept formatted initial model values

### DIFF
--- a/src/br/cep/cep.js
+++ b/src/br/cep/cep.js
@@ -29,7 +29,7 @@ angular.module('ui.utils.masks.br.cep', [])
 				if (ctrl.$isEmpty(value)) {
 					return value;
 				}
-
+				value = clearValue(value);
 				return applyCepMask(value);
 			}
 

--- a/src/br/cep/cep.test.js
+++ b/src/br/cep/cep.test.js
@@ -27,6 +27,15 @@ describe('ui-br-cep-mask', function() {
 		expect(model.$viewValue).toBe('30112-010');
 	});
 
+	it('should accept formatted initial model values', function() {
+		var input = TestUtil.compile('<input ng-model="model" ui-br-cep-mask>', {
+			model: '30112-010'
+		});
+
+		var model = input.controller('ngModel');
+		expect(model.$viewValue).toBe('30112-010');
+	});
+
 	it('should ignore non digits', function() {
 		var input = TestUtil.compile('<input ng-model="model" ui-br-cep-mask>');
 		var model = input.controller('ngModel');


### PR DESCRIPTION
When I assign the cep 30112-010 to the model, it shows on the input as 30112