### PR TITLE
Fixed 0 decimal number formatting

### DIFF
--- a/src/global/number/number.js
+++ b/src/global/number/number.js
@@ -55,7 +55,7 @@ function NumberMaskDirective($locale, $parse, PreFormatters, NumberMasks) {
 				}
 
 				var prefix = (angular.isDefined(attrs.uiNegativeNumber) && value < 0) ? '-' : '';
-				var valueToFormat = PreFormatters.prepareNumberToFormatter(value, decimals) || "0";
+				var valueToFormat = PreFormatters.prepareNumberToFormatter(value, decimals) || '0';
 				return prefix + viewMask.apply(valueToFormat);
 			}
 

--- a/src/global/number/number.js
+++ b/src/global/number/number.js
@@ -55,7 +55,7 @@ function NumberMaskDirective($locale, $parse, PreFormatters, NumberMasks) {
 				}
 
 				var prefix = (angular.isDefined(attrs.uiNegativeNumber) && value < 0) ? '-' : '';
-				var valueToFormat = PreFormatters.prepareNumberToFormatter(value, decimals);
+				var valueToFormat = PreFormatters.prepareNumberToFormatter(value, decimals) || "0";
 				return prefix + viewMask.apply(valueToFormat);
 			}
 


### PR DESCRIPTION
If you selected ui-number-mask="0", then if a angular function updated the value of the model (e.g. in a $http.get callback) to 0, the formatter would strip the "0" down to "", StringMask would refuse to mask that value as a number, and the formatted value on screen would be "undefined". This simply verifies that the value that is being formatted is always a number (if an empty value is returned from PreFormatters.prepareNumberToFormatter, then it is updated to "0".
