### PR TITLE
Fixes Issue #120

### DIFF
--- a/src/global/percentage/percentage.js
+++ b/src/global/percentage/percentage.js
@@ -13,6 +13,8 @@ function PercentageMaskDirective($locale, $parse, PreFormatters, NumberMasks) {
 				thousandsDelimiter = $locale.NUMBER_FORMATS.GROUP_SEP,
 				decimals = parseInt(attrs.uiPercentageMask);
 
+			var bWasEmpty = true;
+
 			var modelValue = {
 				multiplier : 100,
 				decimalMask: 2
@@ -37,7 +39,10 @@ function PercentageMaskDirective($locale, $parse, PreFormatters, NumberMasks) {
 
 			function formatter(value) {
 				if (ctrl.$isEmpty(value)) {
+					bWasEmpty = true;
 					return value;
+				} else {
+					bWasEmpty = false;
 				}
 
 				var valueToFormat = preparePercentageToFormatter(value, decimals, modelValue.multiplier);
@@ -46,15 +51,19 @@ function PercentageMaskDirective($locale, $parse, PreFormatters, NumberMasks) {
 
 			function parse(value) {
 				if (ctrl.$isEmpty(value)) {
+					bWasEmpty = true;
 					return value;
 				}
 
 				var valueToFormat = PreFormatters.clearDelimitersAndLeadingZeros(value) || '0';
-				if (value.length > 1 && value.indexOf('%') === -1) {
-					valueToFormat = valueToFormat.slice(0,valueToFormat.length-1);
+				if (value.length > 0 && value.indexOf('%') === -1 && !bWasEmpty) {
+					valueToFormat = (value.length === 1) ? 0 : valueToFormat.slice(0, valueToFormat.length - 1);
 				}
+
+				bWasEmpty = false;
 				var formatedValue = viewMask.apply(valueToFormat) + ' %';
 				var actualNumber = parseFloat(modelMask.apply(valueToFormat));
+				actualNumber = (isNaN(actualNumber)) ? 0 : actualNumber;
 
 				if (ctrl.$viewValue !== formatedValue) {
 					ctrl.$setViewValue(formatedValue);

--- a/src/global/percentage/percentage.test.js
+++ b/src/global/percentage/percentage.test.js
@@ -125,4 +125,16 @@ describe('ui-percentage-mask', function() {
 		expect(model.$viewValue).toBe('1,234.50 %');
 	}));
 
+	it('should clear to value of 0 % when using zero (0) mask digits', inject(function($rootScope) {
+		var input = TestUtil.compile('<input ng-model="model" ui-percentage-mask="0">', {
+			model: 0.75
+		});
+
+		var model = input.controller('ngModel');
+		expect(model.$viewValue).toBe('75 %');
+		input.val('75 ').triggerHandler('input');
+		expect(model.$viewValue).toBe('7 %');
+		input.val('7 ').triggerHandler('input');
+		expect(model.$viewValue).toBe('0 %');
+	}));
 });

--- a/src/global/percentage/percentage.test.js
+++ b/src/global/percentage/percentage.test.js
@@ -125,7 +125,7 @@ describe('ui-percentage-mask', function() {
 		expect(model.$viewValue).toBe('1,234.50 %');
 	}));
 
-	it('should clear to value of 0 % when using zero (0) mask digits', inject(function($rootScope) {
+	it('should clear to value of 0 % when using zero (0) mask digits', function() {
 		var input = TestUtil.compile('<input ng-model="model" ui-percentage-mask="0">', {
 			model: 0.75
 		});
@@ -136,5 +136,5 @@ describe('ui-percentage-mask', function() {
 		expect(model.$viewValue).toBe('7 %');
 		input.val('7 ').triggerHandler('input');
 		expect(model.$viewValue).toBe('0 %');
-	}));
+	});
 });


### PR DESCRIPTION
Fixes issue where a user is unable to clear the last digit using the BACKSPACE key. This issue occurs when the percentage mask is configured with zero ("0") mask digits.
