### PR TITLE
fix(br-cep): force cep input to string

### DIFF
--- a/src/br/cep/cep.js
+++ b/src/br/cep/cep.js
@@ -5,7 +5,7 @@ var cepMask = new StringMask('00000-000');
 
 module.exports = maskFactory({
 	clearValue: function(rawValue) {
-		return rawValue.replace(/[^0-9]/g, '').slice(0, 8);
+		return rawValue.toString().replace(/[^0-9]/g, '').slice(0, 8);
 	},
 	format: function(cleanValue) {
 		return (cepMask.apply(cleanValue) || '').replace(/[^0-9]$/, '');

--- a/src/br/cep/cep.test.js
+++ b/src/br/cep/cep.test.js
@@ -20,6 +20,15 @@ describe('ui-br-cep-mask', function() {
 		expect(maskedModel.$formatters.length).toBe(model.$formatters.length + 1);
 	});
 
+	it('should convert number inputs to correct format', function() {
+		var input = TestUtil.compile('<input ng-model="model" ui-br-cep-mask>', {
+			model: 30112010
+		});
+
+		var model = input.controller('ngModel');
+		expect(model.$viewValue).toBe('30112-010');
+	});
+
 	it('should format initial model values', function() {
 		var input = TestUtil.compile('<input ng-model="model" ui-br-cep-mask>', {
 			model: '30112010'


### PR DESCRIPTION
I found an issue when getting backend data, if they are setted as number, the mask would fail, the rawValue  was detected as undefined.
Inserting a .toString() before the replace solved the problem.