### PR TITLE
Enabled custom date masks and support for non-Date models

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,21 @@ Some masks are internationalized, so you need to include the proper angular-loca
 ```html
 <input type="text" name="field" ng-model="initializeTime" ui-time-mask="short">
 ```
+
+### ui-time-date ###
+-Example:
+
+```html
+<input type="text" name="field" ng-model="birthDate" ui-date-mask>
+```
+- Support to the custom date masks (See moment.js date formats).
+```html
+<input type="text" name="field" ng-model="birthDate" ui-time-mask="DD-MM-YYYY">
+```
+- Support to ```parse``` attribute. When the attribute is set to ```false```, the inputed value will be passed to the model as a string. Default value of the attribute is ```true```. 
+```html
+<input type="text" name="field" ng-model="birthDate" ui-time-mask parse="false">
+```
 ### More examples ###
 
 _See more usage examples in the [Demo page](http://assisrafael.github.io/angular-input-masks/)_

--- a/src/global/date/date.js
+++ b/src/global/date/date.js
@@ -19,7 +19,9 @@ function DateMaskDirective($locale) {
 	return {
 		restrict: 'A',
 		require: 'ngModel',
-		link: function(scope, element, attrs, ctrl) {
+		link: function (scope, element, attrs, ctrl) {
+			dateFormat = attrs.uiDateMask || dateFormat;
+
 			var dateMask = new StringMask(dateFormat.replace(/[YMD]/g,'0'));
 
 			function formatter(value) {

--- a/src/global/date/date.js
+++ b/src/global/date/date.js
@@ -19,7 +19,9 @@ function DateMaskDirective($locale) {
 	return {
 		restrict: 'A',
 		require: 'ngModel',
-		link: function (scope, element, attrs, ctrl) {
+		link: function(scope, element, attrs, ctrl) {
+			attrs.parse = attrs.parse || 'true';
+
 			dateFormat = attrs.uiDateMask || dateFormat;
 
 			var dateMask = new StringMask(dateFormat.replace(/[YMD]/g,'0'));
@@ -54,7 +56,9 @@ function DateMaskDirective($locale) {
 					ctrl.$render();
 				}
 
-				return moment(formatedValue, dateFormat).toDate();
+				return attrs.parse === 'false'
+					? formatedValue
+					: moment(formatedValue, dateFormat).toDate();
 			});
 
 			ctrl.$validators.date =	function validator(modelValue, viewValue) {

--- a/src/global/date/date.spec.js
+++ b/src/global/date/date.spec.js
@@ -27,13 +27,13 @@ describe('ui.utils.masks.date', function() {
 					expect(input.getAttribute('value')).toEqual(formatedDateAsString);
 				}
 
-				expect(value.getText()).toEqual(moment(formatedDateAsString, 'YYYY-MM-DD').toDate().toString());
+				expect(value.evaluate('dateMask.toString()')).toEqual(moment(formatedDateAsString, 'YYYY-MM-DD').toDate().toString());
 
 				for (i = 7; i >= 0; i--) {
 					input.sendKeys(protractor.Key.BACK_SPACE);
 					numberToFormat = numberToFormat.slice(0, -1);
 					if (numberToFormat) {
-						formatedDateAsString = dateFormatter.apply(numberToFormat).replace(/-$/,'');
+						formatedDateAsString = dateFormatter.apply(numberToFormat).replace(/-$/, '');
 						expect(input.getAttribute('value')).toEqual(formatedDateAsString);
 					}
 				}
@@ -43,8 +43,8 @@ describe('ui.utils.masks.date', function() {
 				var input = element(by.model('initializedDateMask')),
 					value = element(by.exactBinding('initializedDateMask'));
 
-				value.getText().then((textValue) => {
-					var dateValue = moment(new Date(textValue)).format('YYYY-MM-DD');
+				value.evaluate('initializedDateMask').then((initialValue) => {
+					var dateValue = moment(initialValue).format('YYYY-MM-DD');
 					expect(input.getAttribute('value')).toEqual(dateValue);
 				});
 			});
@@ -108,7 +108,7 @@ describe('ui.utils.masks.date', function() {
 					expect(input.getAttribute('value')).toEqual(formatedDateAsString);
 				}
 
-				expect(value.getText()).toEqual(moment(formatedDateAsString, 'DD/MM/YYYY').toDate().toString());
+				expect(value.evaluate('dateMask.toString()')).toEqual(moment(formatedDateAsString, 'DD/MM/YYYY').toDate().toString());
 
 				for (i = 7; i >= 0; i--) {
 					input.sendKeys(protractor.Key.BACK_SPACE);
@@ -124,8 +124,8 @@ describe('ui.utils.masks.date', function() {
 				var input = element(by.model('initializedDateMask')),
 					value = element(by.exactBinding('initializedDateMask'));
 
-				value.getText().then((textValue) => {
-					var dateValue = moment(new Date(textValue)).format('DD/MM/YYYY');
+				value.evaluate('initializedDateMask').then((initialValue) => {
+					var dateValue = moment(initialValue).format('DD/MM/YYYY');
 					expect(input.getAttribute('value')).toEqual(dateValue);
 				});
 			});

--- a/src/global/date/date.test.js
+++ b/src/global/date/date.test.js
@@ -30,6 +30,15 @@ describe('ui-date-mask', function() {
 		var model = input.controller('ngModel');
 		expect(model.$viewValue).toBe('1999-12-31');
 	});
+    
+    it('should use specified mask', function() {
+		var input = TestUtil.compile('<input ng-model="model" ui-date-mask="DD.MM.YYYY">', {
+			model: new Date('1999-12-31 00:00:00')
+		});
+
+		var model = input.controller('ngModel');
+		expect(model.$viewValue).toBe('31.12.1999');
+	});
 
 	it('should ignore non digits', function() {
 		var input = TestUtil.compile('<input ng-model="model" ui-date-mask>');

--- a/src/global/date/date.test.js
+++ b/src/global/date/date.test.js
@@ -30,8 +30,8 @@ describe('ui-date-mask', function() {
 		var model = input.controller('ngModel');
 		expect(model.$viewValue).toBe('1999-12-31');
 	});
-    
-    it('should use specified mask', function() {
+
+	it('should use specified mask', function() {
 		var input = TestUtil.compile('<input ng-model="model" ui-date-mask="DD.MM.YYYY">', {
 			model: new Date('1999-12-31 00:00:00')
 		});
@@ -58,6 +58,20 @@ describe('ui-date-mask', function() {
 			expect(model.$viewValue).toBe(test.viewValue);
 		});
 	});
+
+	it('should parse input', angular.mock.inject(function($rootScope) {
+		var input = TestUtil.compile('<input ng-model="model" ui-date-mask>');
+
+		input.val('1999-12-31').triggerHandler('input');
+		expect($rootScope.model instanceof Date).toBe(true);
+	}));
+
+	it('should not parse input when parse disabled', angular.mock.inject(function($rootScope) {
+		var input = TestUtil.compile('<input ng-model="model" ui-date-mask parse="false">');
+
+		input.val('1999-12-31').triggerHandler('input');
+		expect(typeof ($rootScope.model) === 'string').toBe(true);
+	}));
 
 	it('should handle corner cases', angular.mock.inject(function($rootScope) {
 		var input = TestUtil.compile('<input ng-model="model" ui-date-mask>');


### PR DESCRIPTION
Hi.

I think it could be useful to have a way to customize actual mask format.
Also in our project we have to treat model value as a string. Yo achieve this 'parse' flag was added. Perhaps this functionality will be useful for someone else.