### PR TITLE
fix(uiPercentageMask): honor ui-hide-space when view value change due…

### DIFF
--- a/src/global/percentage/percentage.js
+++ b/src/global/percentage/percentage.js
@@ -53,7 +53,7 @@ function PercentageMaskDirective($locale, $parse, PreFormatters, NumberMasks) {
 				}
 
 				var valueToFormat = preparePercentageToFormatter(value, decimals, modelValue.multiplier);
-				return viewMask.apply(valueToFormat) + ' %';
+				return viewMask.apply(valueToFormat) + (hideSpace ? '%' : ' %');
 			}
 
 			function parse(value) {

--- a/src/global/percentage/percentage.test.js
+++ b/src/global/percentage/percentage.test.js
@@ -64,7 +64,7 @@ describe('ui-percentage-mask', function() {
 		expect(model.$viewValue).toBe('100%');
 	});
 
-	it('should hide space before "%" if ui-hide-space is present and model value is changed', function() {
+	it('should hide space before "%" if ui-hide-space is present and model value is changed', function($rootScope) {
 		var input = TestUtil.compile('<input ng-model="model" ui-percentage-mask="decimals" ui-percentage-value ui-hide-space>', {
 			model: 1,
 			decimals: 0
@@ -74,7 +74,7 @@ describe('ui-percentage-mask', function() {
 		expect(model.$viewValue).toBe('100%');
 
 		$rootScope.model = 0.5;
-		$rootScope.digest();
+		$rootScope.$digest();
 
 		expect(model.$viewValue).toBe('50%');
 	});

--- a/src/global/percentage/percentage.test.js
+++ b/src/global/percentage/percentage.test.js
@@ -64,6 +64,21 @@ describe('ui-percentage-mask', function() {
 		expect(model.$viewValue).toBe('100%');
 	});
 
+	it('should hide space before "%" if ui-hide-space is present and model value is changed', function() {
+		var input = TestUtil.compile('<input ng-model="model" ui-percentage-mask="decimals" ui-percentage-value ui-hide-space>', {
+			model: 1,
+			decimals: 0
+		});
+
+		var model = input.controller('ngModel');
+		expect(model.$viewValue).toBe('100%');
+
+		$rootScope.model = 0.5;
+		$rootScope.digest();
+
+		expect(model.$viewValue).toBe('50%');
+	});
+
 	it('should allow changing the number of decimals', angular.mock.inject(function($rootScope) {
 		var input = TestUtil.compile('<input ng-model="model" ui-percentage-mask="decimals">', {
 			model: '12.345',


### PR DESCRIPTION
… to model update from controller

Previously, a change to the model in the controller would result in a space in between the percent sign and the value no matter if the ui-hide-space attribute is present or not.  Now, a change to the model will result in the correct view value format.

Non-breaking change.