### PR TITLE
Add support for custom decimal and thousands delimiters

### DIFF
--- a/src/global/money/money.js
+++ b/src/global/money/money.js
@@ -21,6 +21,14 @@ function MoneyMaskDirective($locale, $parse, PreFormatters) {
 				return new StringMask(maskPattern, {reverse: true});
 			}
 
+			if (angular.isDefined(attrs.uiDecimalDelimiter)) {
+				decimalDelimiter = attrs.uiDecimalDelimiter;
+			}
+
+			if (angular.isDefined(attrs.uiThousandsDelimiter)) {
+				thousandsDelimiter = attrs.uiThousandsDelimiter;
+			}
+
 			if (angular.isDefined(attrs.uiHideGroupSep)) {
 				thousandsDelimiter = '';
 			}

--- a/src/global/money/money.test.js
+++ b/src/global/money/money.test.js
@@ -224,8 +224,8 @@ describe('ui-money-mask', function() {
 
 		var model = input.controller('ngModel');
 		expect(model.$viewValue).toBe('$ 123|00');
-  });
-    
+	});
+
 	it('should add currency after value', function() {
 		var input = TestUtil.compile('<input ng-model="model" currency-symbol="EUR"  ui-currency-after ui-money-mask="mdecimals">', {
 			model: 345.00

--- a/src/global/money/money.test.js
+++ b/src/global/money/money.test.js
@@ -207,4 +207,22 @@ describe('ui-money-mask', function() {
 		var model = input.controller('ngModel');
 		expect(model.$viewValue).toBe('345.00');
 	});
+
+	it('should employ a custom thousands delimiter', function() {
+		var input = TestUtil.compile('<input ng-model="model" ui-money-mask ui-thousands-delimiter="|">', {
+			model: 1234567.00
+		});
+
+		var model = input.controller('ngModel');
+		expect(model.$viewValue).toBe('$ 1|234|567.00');
+	});
+
+	it('should employ a custom decimal delimiter', function() {
+		var input = TestUtil.compile('<input ng-model="model" ui-money-mask ui-decimal-delimiter="|">', {
+			model: 123.00
+		});
+
+		var model = input.controller('ngModel');
+		expect(model.$viewValue).toBe('$ 123|00');
+	});
 });


### PR DESCRIPTION
Adds two new attributes to the `ui-money-mask` directive:

- `ui-decimal-delimiter`
- `ui-thousands-delimiter`

This allows support for projects that do not depend on the browser's locale for all localization information (for example, if a user is able to select a custom currency as an application setting).