### PR TITLE
changing the run webdriver manager to run e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,12 @@
     "lint": "eslint *.js src/ config/ --fix",
     "test": "npm run test:unit && npm run test:e2e",
     "pretest:e2e": "npm run build",
-    "test:e2e": "protractor config/protractor.conf.js",
+    "test:e2e": "npm run webdriver && protractor config/protractor.conf.js",
     "test:unit": "karma start config/karma.conf.js --single-run",
     "test:unit:watch": "karma start config/karma.conf.js --auto-watch",
     "prepare": "npm run build",
     "release": "standard-version",
-    "webdriver": "webdriver-manager update",
-    "postinstall": "npm run webdriver"
+    "webdriver": "webdriver-manager update"
   },
   "keywords": [
     "input",


### PR DESCRIPTION
Removed webdriver-manager from postinstall, and added to the "test:e2e" instruction. Changing, because "npm install --prod" not working, and broke installation for the production enviroment only.