### PR TITLE
Money: format and parse integer models

### DIFF
--- a/src/global/money/money.js
+++ b/src/global/money/money.js
@@ -64,6 +64,9 @@ function MoneyMaskDirective($locale, $parse) {
 				if (ctrl.$isEmpty(value)) {
 					return value;
 				}
+				if (angular.isDefined(attrs.uiIntegerModel)) {
+						value = value / Math.pow(10, decimals);
+				}
 				var prefix = (angular.isDefined(attrs.uiNegativeNumber) && value < 0) ? '-' : '';
 				var valueToFormat = PreFormatters.prepareNumberToFormatter(value, decimals);
 				if (angular.isDefined(attrs.uiCurrencyAfter)) {
@@ -109,7 +112,15 @@ function MoneyMaskDirective($locale, $parse) {
 					ctrl.$render();
 				}
 
-				return formatedValue ? parseInt(formatedValue.replace(/[^\d\-]+/g,''))/Math.pow(10,decimals) : null;
+				var retValue = parseInt(formatedValue.replace(/[^\d\-]+/g,''));
+				if (!isNaN(retValue)) {
+						if (!angular.isDefined(attrs.uiIntegerModel)) {
+								retValue = retValue / Math.pow(10, decimals);
+						}
+						return retValue;
+				} else {
+						return null;
+				}
 			}
 
 			ctrl.$formatters.push(formatter);

--- a/src/global/money/money.test.js
+++ b/src/global/money/money.test.js
@@ -269,4 +269,22 @@ describe('ui-money-mask', function() {
 		var model = input.controller('ngModel');
 		expect(model.$viewValue).toBe('345.00 EUR');
 	});
+
+	it('should format integer models', function() {
+		var input = TestUtil.compile('<input ng-model="model" ui-money-mask ui-integer-model>', {
+				model: 12345
+		});
+
+		var model = input.controller('ngModel');
+		expect(model.$viewValue).toBe('$ 123.45');
+	});
+
+	it('should parse integer models', function() {
+		var input = TestUtil.compile('<input ng-model="model" ui-money-mask ui-integer-model>', {});
+		var model = input.controller('ngModel');
+
+		input.val('123.45').triggerHandler('input');
+		expect(model.$viewValue).toBe('$ 123.45');
+		expect(model.$modelValue).toBe(12345);
+	});
 });


### PR DESCRIPTION
It's quite common to store money values as integers, to avoid floating point rounding errors.

It would be great to have `angular-input-masks` automagically perform this conversion, therefore I have added a new attr `ui-integer-model` which allows an integer model to be displayed as the right decimal amount and of course parse it back.

For example, if my model is `12345` and I use the standard 2 decimals, it will be displayed as `$ 123.45` and parsed the other way around: if my input contains `$ 567.90` it will become `56790` in the model.