### PR TITLE
fix caret jumps to end of field on edit/delete

### DIFF
--- a/src/helpers/mask-factory.js
+++ b/src/helpers/mask-factory.js
@@ -11,21 +11,20 @@ module.exports = function maskFactory(maskDefinition) {
 					var range = document.selection.createRange();
 					range.moveStart('character', -element.value.length);
 					caretPosition = range.text.length;
-				} else if (element.selectionStart || element.selectionStart == '0') {
+				} else if (element.selectionStart || element.selectionStart === '0') {
 					caretPosition = element.selectionStart;
 				}
 				return caretPosition;
 			},
 			set: function setCaretPosition(element, position) {
-				
-				if (/[^0-9a-z]/gi.test(element.value.charAt(position - 1))
+				if (/[^\w]/gi.test(element.value.charAt(position - 1))
 					&& element.value.charAt(position + 1) === null && !isBackspace) {
 					position += /\s/.test(element.value.charAt(position)) ? 3 : 2;
-				} else if (/[^0-9a-z]/gi.test(element.value.charAt(position - 1))
+				} else if (/[^\w]/gi.test(element.value.charAt(position - 1))
 					&& element.value.charAt(position + 1) !== null && !isBackspace) {
 					position += /\s/.test(element.value.charAt(position)) ? 2 : 1;
 				}
-
+				
 				if(element.setSelectionRange) {
 					element.focus();
 					setTimeout(function () {
@@ -46,11 +45,7 @@ module.exports = function maskFactory(maskDefinition) {
 			link: function(scope, element, attrs, ctrl) {
 
 				element.on('keydown', function (event) {
-					if(event.keyCode == '8' || event.keyCode == '46'){
-						isBackspace = true;
-					} else {
-						isBackspace = false;
-					}
+					isBackspace = event.keyCode === '8' || event.keyCode === '46';
 				});
 				
 				ctrl.$formatters.push(function formatter(value) {
@@ -70,14 +65,14 @@ module.exports = function maskFactory(maskDefinition) {
 					var cleanValue = maskDefinition.clearValue(value.toString(), attrs);
 					var formattedValue = maskDefinition.format(cleanValue);
 
-					var currentPosition = caretCtrl.get(element[0]);
+					var currentCaretPosition = caretCtrl.get(element[0]);
 
 					if (ctrl.$viewValue !== formattedValue) {
 						ctrl.$setViewValue(formattedValue);
 						ctrl.$render();
 					}
 
-					caretCtrl.set(element[0], currentPosition);
+					caretCtrl.set(element[0], currentCaretPosition);
 
 					if (angular.isUndefined(maskDefinition.getModelValue)) {
 						return cleanValue;

--- a/src/helpers/mask-factory.js
+++ b/src/helpers/mask-factory.js
@@ -17,17 +17,17 @@ module.exports = function maskFactory(maskDefinition) {
 				return caretPosition;
 			},
 			set: function setCaretPosition(element, position) {
-				if (/[^\w]/gi.test(element.value.charAt(position - 1))
-					&& element.value.charAt(position + 1) === null && !isBackspace) {
+				if (/[^\w]/gi.test(element.value.charAt(position - 1)) &&
+					element.value.charAt(position + 1) === null && !isBackspace) {
 					position += /\s/.test(element.value.charAt(position)) ? 3 : 2;
-				} else if (/[^\w]/gi.test(element.value.charAt(position - 1))
-					&& element.value.charAt(position + 1) !== null && !isBackspace) {
+				} else if (/[^\w]/gi.test(element.value.charAt(position - 1)) &&
+					element.value.charAt(position + 1) !== null && !isBackspace) {
 					position += /\s/.test(element.value.charAt(position)) ? 2 : 1;
 				}
-				
-				if(element.setSelectionRange) {
+
+				if (element.setSelectionRange) {
 					element.focus();
-					setTimeout(function () {
+					setTimeout(function() {
 						element.setSelectionRange(position, position);
 					}, 0);
 				} else if (element.createTextRange) {
@@ -38,16 +38,16 @@ module.exports = function maskFactory(maskDefinition) {
 					range.select();
 				}
 			}
-		}
+		};
 		return {
 			restrict: 'A',
 			require: 'ngModel',
 			link: function(scope, element, attrs, ctrl) {
 
-				element.on('keydown', function (event) {
+				element.on('keydown', function(event) {
 					isBackspace = event.keyCode === '8' || event.keyCode === '46';
 				});
-				
+
 				ctrl.$formatters.push(function formatter(value) {
 					if (ctrl.$isEmpty(value)) {
 						return value;

--- a/src/helpers/mask-factory.js
+++ b/src/helpers/mask-factory.js
@@ -2,10 +2,57 @@
 
 module.exports = function maskFactory(maskDefinition) {
 	return function MaskDirective() {
+		var isBackspace = false;
+		var caretCtrl = {
+			get: function getCaretPosition(element) {
+				var caretPosition = 0;
+				if (document.selection) {
+					element.focus();
+					var range = document.selection.createRange();
+					range.moveStart('character', -element.value.length);
+					caretPosition = range.text.length;
+				} else if (element.selectionStart || element.selectionStart == '0') {
+					caretPosition = element.selectionStart;
+				}
+				return caretPosition;
+			},
+			set: function setCaretPosition(element, position) {
+				
+				if (/[^0-9a-z]/gi.test(element.value.charAt(position - 1))
+					&& element.value.charAt(position + 1) === null && !isBackspace) {
+					position += /\s/.test(element.value.charAt(position)) ? 3 : 2;
+				} else if (/[^0-9a-z]/gi.test(element.value.charAt(position - 1))
+					&& element.value.charAt(position + 1) !== null && !isBackspace) {
+					position += /\s/.test(element.value.charAt(position)) ? 2 : 1;
+				}
+
+				if(element.setSelectionRange) {
+					element.focus();
+					setTimeout(function () {
+						element.setSelectionRange(position, position);
+					}, 0);
+				} else if (element.createTextRange) {
+					var range = element.createTextRange();
+					range.collapse(true);
+					range.moveEnd('character', position);
+					range.moveStart('character', position);
+					range.select();
+				}
+			}
+		}
 		return {
 			restrict: 'A',
 			require: 'ngModel',
 			link: function(scope, element, attrs, ctrl) {
+
+				element.on('keydown', function (event) {
+					if(event.keyCode == '8' || event.keyCode == '46'){
+						isBackspace = true;
+					} else {
+						isBackspace = false;
+					}
+				});
+				
 				ctrl.$formatters.push(function formatter(value) {
 					if (ctrl.$isEmpty(value)) {
 						return value;
@@ -23,10 +70,14 @@ module.exports = function maskFactory(maskDefinition) {
 					var cleanValue = maskDefinition.clearValue(value.toString(), attrs);
 					var formattedValue = maskDefinition.format(cleanValue);
 
+					var currentPosition = caretCtrl.get(element[0]);
+
 					if (ctrl.$viewValue !== formattedValue) {
 						ctrl.$setViewValue(formattedValue);
 						ctrl.$render();
 					}
+
+					caretCtrl.set(element[0], currentPosition);
 
 					if (angular.isUndefined(maskDefinition.getModelValue)) {
 						return cleanValue;


### PR DESCRIPTION
This resolution is continuity of what was started by @viict, some adjustments were made to finally solve the problem that causes the cursor to jump to the end of the field when trying to edit or delete its value in the middle. This solution was tested only with BR masks.